### PR TITLE
Renamed toolbutton to fit casing

### DIFF
--- a/frontend/src/app/features/project-editor/components/sidebar/toolbar/toolbar.html
+++ b/frontend/src/app/features/project-editor/components/sidebar/toolbar/toolbar.html
@@ -1,9 +1,9 @@
 <div class="pe-toolbar">
-  <app-toolbutton icon="icons/sweater.png"   alt="Presets"   [selected]="selectedTool === 'Presets'"   (clicked)="onToolClick('Presets')">Presets</app-toolbutton>
+  <app-tool-button icon="icons/sweater.png"   alt="Presets"   [selected]="selectedTool === 'Presets'"   (clicked)="onToolClick('Presets')">Presets</app-tool-button>
   <hr>
-  <app-toolbutton icon="icons/2D_shapes.png" alt="2D shapes" [selected]="selectedTool === '2D shapes'" (clicked)="onToolClick('2D shapes')">2D shapes</app-toolbutton>
-  <app-toolbutton icon="icons/3D_shapes.png" alt="3D shapes" [selected]="selectedTool === '3D shapes'" (clicked)="onToolClick('3D shapes')">3D shapes</app-toolbutton>
+  <app-tool-button icon="icons/2D_shapes.png" alt="2D shapes" [selected]="selectedTool === '2D shapes'" (clicked)="onToolClick('2D shapes')">2D shapes</app-tool-button>
+  <app-tool-button icon="icons/3D_shapes.png" alt="3D shapes" [selected]="selectedTool === '3D shapes'" (clicked)="onToolClick('3D shapes')">3D shapes</app-tool-button>
   <hr>
-  <app-toolbutton icon="icons/yarn.png"      alt="Yarns"     [selected]="selectedTool === 'Yarns'"     (clicked)="onToolClick('Yarns')">Yarns</app-toolbutton>
-  <app-toolbutton icon="icons/table.png"     alt="Stitch Chart"  [selected]="selectedTool === 'Stitch Chart'"  (clicked)="onToolClick('Stitch Chart')">Stitch Chart</app-toolbutton>
+  <app-tool-button icon="icons/yarn.png"      alt="Yarns"     [selected]="selectedTool === 'Yarns'"     (clicked)="onToolClick('Yarns')">Yarns</app-tool-button>
+  <app-tool-button icon="icons/table.png"     alt="Stitch Chart"  [selected]="selectedTool === 'Stitch Chart'"  (clicked)="onToolClick('Stitch Chart')">Stitch Chart</app-tool-button>
 </div>

--- a/frontend/src/app/features/project-editor/components/sidebar/toolbar/toolbar.ts
+++ b/frontend/src/app/features/project-editor/components/sidebar/toolbar/toolbar.ts
@@ -1,9 +1,9 @@
 import { Component, Output, EventEmitter } from '@angular/core';
-import { Toolbutton } from '../../../../../shared/components/buttons/toolbutton/toolbutton';
+import { ToolButton } from '../../../../../shared/components/buttons/tool-button/tool-button';
 
 @Component({
   selector: 'app-toolbar',
-  imports: [Toolbutton],
+  imports: [ToolButton],
   templateUrl: './toolbar.html',
   styleUrl: './toolbar.css',
 })

--- a/frontend/src/app/shared/components/buttons/tool-button/tool-button.css
+++ b/frontend/src/app/shared/components/buttons/tool-button/tool-button.css
@@ -1,5 +1,5 @@
 
-.toolbutton {
+.tool-button {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -17,8 +17,8 @@
   height: 35px;
 }
 
-.toolbutton:hover .icon,
-.toolbutton.selected .icon {
+.tool-button:hover .icon,
+.tool-button.selected .icon {
   background-color: lightgray;
   border-radius: 10px;
 }

--- a/frontend/src/app/shared/components/buttons/tool-button/tool-button.html
+++ b/frontend/src/app/shared/components/buttons/tool-button/tool-button.html
@@ -1,4 +1,4 @@
-<button class="toolbutton" [class.selected]="selected" (click)="clicked.emit()">
+<button class="tool-button" [class.selected]="selected" (click)="clicked.emit()">
   <img [src]="icon" [alt]="alt ?? ''" class="icon" />
   <span class="label"><ng-content></ng-content></span>
 </button>

--- a/frontend/src/app/shared/components/buttons/tool-button/tool-button.spec.ts
+++ b/frontend/src/app/shared/components/buttons/tool-button/tool-button.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Toolbutton } from './toolbutton';
+import { ToolButton } from './tool-button';
 
-describe('Toolbutton', () => {
-  let component: Toolbutton;
-  let fixture: ComponentFixture<Toolbutton>;
+describe('ToolButton', () => {
+  let component: ToolButton;
+  let fixture: ComponentFixture<ToolButton>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Toolbutton]
+      imports: [ToolButton]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Toolbutton);
+    fixture = TestBed.createComponent(ToolButton);
     component = fixture.componentInstance;
     await fixture.whenStable();
   });

--- a/frontend/src/app/shared/components/buttons/tool-button/tool-button.ts
+++ b/frontend/src/app/shared/components/buttons/tool-button/tool-button.ts
@@ -2,12 +2,12 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
-  selector: 'app-toolbutton',
+  selector: 'app-tool-button',
   imports: [CommonModule],
-  templateUrl: './toolbutton.html',
-  styleUrl: './toolbutton.css',
+  templateUrl: './tool-button.html',
+  styleUrl: './tool-button.css',
 })
-export class Toolbutton {
+export class ToolButton {
   @Input() icon?: string;
   @Input() alt?: string;
   @Input() selected = false;


### PR DESCRIPTION
This PR Add on top of #18 as we overlooked the naming of buttons in the shared folder.

This pr fixes the naming of ToolButtons s.t. it fits the naming conventions set.

This involves #16.