### PR TITLE
Containerisation

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.angular

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,3 +1,2 @@
 node_modules
-dist
 .angular

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist/knit-frontend/browser /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,15 @@
 # KnitFrontend
 
+## Containerisation
+
+This component of the KnittingProject is containerised using [Docker](https://docs.docker.com/). In order to build and run the frontend use:
+
+```bash
+docker build -t knit-frontend ./frontend
+docker run -p 8080:80 knit-frontend
+```
+
+
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 21.1.4.
 
 ## Development server


### PR DESCRIPTION
# Introduction

In order to better the reproducibility of code, we had decided to begin containerising the project. Hence, this PR adds the relevant dockerfiles to make a frontend docker container.

# Updates

The PR includes important dockerfiles. These being `Dockerfile` and `.dockerignore` along with instructions on how to build and run the docker container.

About dockerfile:
- Uses Alpine node image as a base to build on a lean linux distro.
- Uses nginx to be more prod ready